### PR TITLE
fixed the issue which only open (to join) teams gets loaded at login

### DIFF
--- a/mattermost_bot/mattermost_v4.py
+++ b/mattermost_bot/mattermost_v4.py
@@ -29,7 +29,7 @@ class MattermostAPIv4(MattermostAPI):
             response.raise_for_status()
 
     def load_initial_data(self):
-        self.teams = self.get('/teams')
+        self.teams = self.get('/users/me/teams')
         self.default_team_id = self.teams[0]['id']
         self.teams_channels_ids = {}
         for team in self.teams:


### PR DESCRIPTION
this was caused by misuse of APIv4: 
- the '/teams' endpoint returns only open teams. 
- we need to use '/users/{user_id}/teams' to get all teams

referred discussion: https://forum.mattermost.org/t/solved-mattermost-v3-to-v4-upgrade-team-api-v4/4156/6