### PR TITLE
Deal with possible login redirection

### DIFF
--- a/mattermost_bot/mattermost.py
+++ b/mattermost_bot/mattermost.py
@@ -44,8 +44,16 @@ class MattermostAPI(object):
         props = {'name': name, 'login_id': email, 'password': password}
         p = requests.post(
             self.url + '/users/login', data=json.dumps(props),
-            verify=self.ssl_verify
+            verify=self.ssl_verify, allow_redirects=False
         )
+        if p.status_code in [301, 302, 307]:
+            # reset self.url to the new URL
+            self.url = response.headers['Location'].replace('/users/login', '')
+            # re-try login if redirected
+            p = requests.post(
+                self.url + '/users/login', data = json.dumps(props),
+                verify=self.ssl_verify, allow_redirects=False
+            )
         if p.status_code == 200:
             self.token = p.headers["Token"]
             self.load_initial_data()

--- a/mattermost_bot/settings.py
+++ b/mattermost_bot/settings.py
@@ -37,7 +37,7 @@ for key in os.environ:
     if key[:15] == 'MATTERMOST_BOT_':
         globals()[key[11:]] = os.environ[key]
 
-settings_module = os.environ['MATTERMOST_BOT_SETTINGS_MODULE']
+settings_module = os.environ.get('MATTERMOST_BOT_SETTINGS_MODULE')
 
 if settings_module is not None:
     pwd = os.getcwd()


### PR DESCRIPTION
A fix to issue #15.

Possibly caused by URL redirection rules of general web servers. The redirection can be handled by most web browsers, but not python-requests package.

This solution sets `allow_redirects=False`, and catches HTTP error code 301, 302, or 307, and then makes second login request with returned new URL.

Related discussions:
 * [stackoverflow: Curl works but not Python requests](https://stackoverflow.com/questions/24970333/curl-works-but-not-python-requests)
 * requests/requests#1358 : HTTPDigest working with CURL but not Requests?
 * requests/requests#2848 : Session's Authorization header isn't sent on redirect