### PR TITLE
Deal with possible login redirection (working_apiv4)

### DIFF
--- a/mattermost_bot/mattermost.py
+++ b/mattermost_bot/mattermost.py
@@ -42,10 +42,20 @@ class MattermostAPI(object):
 
     def login(self, team, account, password):
         props = {'login_id': account, 'password': password}
-        response =requests.post(
+        response = requests.post(
             self.url + '/users/login',
             data = json.dumps(props),
-            verify=self.ssl_verify)
+            verify=self.ssl_verify,
+            allow_redirects=False)
+        if response.status_code in [301, 302, 307]:
+            # reset self.url to the new URL
+            self.url = response.headers['Location'].replace('/users/login', '')
+            # re-try login if redirected
+            response = requests.post(
+                self.url + '/users/login',
+                data = json.dumps(props),
+                verify=self.ssl_verify,
+                allow_redirects=False)
         if response.status_code == 200:
             self.token = response.headers["Token"]
             self.load_initial_data()


### PR DESCRIPTION
A fix to issue #15.

Possibly caused by URL redirection rules of general web servers. The redirection can be handled by most web browsers, but not python-requests package.

This solution sets `allow_redirects=False`, and catches HTTP error code 301, 302, or 307, and then makes second login request with returned new URL.

Related discussions:
 * [stackoverflow: Curl works but not Python requests](https://stackoverflow.com/questions/24970333/curl-works-but-not-python-requests)
 * requests/requests#1358 : HTTPDigest working with CURL but not Requests?
 * requests/requests#2848 : Session's Authorization header isn't sent on redirect